### PR TITLE
Clean slate

### DIFF
--- a/doPkgUp.sh
+++ b/doPkgUp.sh
@@ -64,10 +64,6 @@ echo "PKG_DBDIR: /var/db/trueos-update/pkgdb" >> /var/db/trueos-update/.pkgUpdat
 echo "Removing old packages... Please wait..."
 pkg-static ${PKG_CFLAG} ${PKG_FLAG} unlock -ay
 
-# Bad PKG, bad!
-pkg-static ${PKG_CFLAG} ${PKG_FLAG} delete -y javavmwrapper-2.5_1 2>/dev/null >/dev/null
-pkg-static ${PKG_CFLAG} ${PKG_FLAG} delete -y javavmwrapper-2.5_2 2>/dev/null >/dev/null
-
 # Since we cant remove pkgs via repository, this will have to do
 pkg-static query -e '%n !~ FreeBSD-*' %o | xargs pkg-static ${PKG_CFLAG} ${PKG_FLAG} delete -fy
 if [ $? -ne 0 ] ; then

--- a/trueos-update
+++ b/trueos-update
@@ -560,6 +560,17 @@ prep_pkgs_chroot()
   # Unlock all packages first
   ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} unlock -ay >>${LOGOUT} 2>>${LOGOUT}
 
+  # Check if we have -devel or -debug packages and re-install them
+  DEVPKG="NO"
+  DEBUGPKG="NO"
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} info -g FreeBSD-\* | grep -q -e '-development-'
+  if [ $? -eq 0 ] ; then
+    DEVPKG="YES"
+  fi
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} info -g FreeBSD-\* | grep -q -e '-debug-'
+  if [ $? -eq 0 ] ; then
+    DEBUGPKG="YES"
+  fi
 
   # Remove *ALL* the packages, we need a clean slate to avoid pkg conflicts going sideways
   ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} delete -yg \* >>${LOGOUT} 2>>${LOGOUT}
@@ -569,12 +580,36 @@ prep_pkgs_chroot()
   fi
 
   # Install the base system packages first
-  echo_log "Upgrading base packages..."
-  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} install -yfg 'FreeBSD-*' >>${LOGOUT} 2>>${LOGOUT}
-  if [ $? -ne 0 ] ; then
-    echo_log "FAILED INSTALLING world base packages"
-    exit 1
-  fi
+  echo_log "Installing base packages..."
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} search -g 'FreeBSD-*' \
+	| awk '{print $1}'  > /tmp/.fpkg.$$
+  while read fpkg
+  do
+    echo "$fpkg" | grep -q -e '-development-'
+    if [ $? -eq 0 -a "$DEVPKG" = "YES" ] ; then
+      echo_log "Skipping DEVELOPMENT package: $fpkg"
+      continue
+    fi
+    if [ $? -eq 0 -a "$DEBUGPKG" = "YES" ] ; then
+      echo_log "Skipping DEBUG package: $fpkg"
+      continue
+    fi
+
+    ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} info -q $fpkg
+    if [ $? -eq 0 ] ; then
+      echo_log "Skipping installed package: $fpkg"
+      continue
+    fi
+
+    # Install the base system package now
+    ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} install -yf $fpkg >>${LOGOUT} 2>>${LOGOUT}
+    if [ $? -ne 0 ] ; then
+      echo_log "FAILED INSTALLING world base package: $fpkg"
+      rm /tmp/.fpkg.$$
+      exit 1
+    fi
+  done < /tmp/.fpkg.$$
+  rm /tmp/.fpkg.$$
 
   # Set all pkgs as not auto-installed, so pkg autoremove doesn't touch them
   echo_log "Marking FreeBSD packages as not auto-installed"
@@ -582,12 +617,8 @@ prep_pkgs_chroot()
 
   # Check if something went horribly wrong
   if [ ! -e "${STAGEMNT}/bin/sh" ] ; then
-     ABI_FLAG="-o ABI=freebsd:`uname -r | cut -c 1-2`:`uname -m`"
-     ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} install -yfg 'FreeBSD-*' >>${LOGOUT} 2>>${LOGOUT}
-     if [ ! -e "${STAGEMNT}/bin/sh" ] ; then
-       echo_log "Missing ${STAGEMNT}/bin/sh: Something went horribly wrong!"
-       exit 1
-     fi
+    echo_log "Missing ${STAGEMNT}/bin/sh: Something went horribly wrong!"
+    exit 1
   fi
 
   # Workaround to issue in FreeBSD pkg base

--- a/trueos-update
+++ b/trueos-update
@@ -558,7 +558,9 @@ prep_pkgs_chroot()
   fi
 
   # Unlock all packages first
+  echo_log "Unlocking packages..."
   ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} unlock -ay >>${LOGOUT} 2>>${LOGOUT}
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} set -a -v 0 >>${LOGOUT} 2>>${LOGOUT}
 
   # Check if we have -devel or -debug packages and re-install them
   DEVPKG="NO"
@@ -572,10 +574,25 @@ prep_pkgs_chroot()
     DEBUGPKG="YES"
   fi
 
+  # Determine which packages are installed
+  echo_log "Installing base packages..."
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} search -g 'FreeBSD-*' \
+	| awk '{print $1}'  > /tmp/.fpkg.$$
+
+  echo_log "Deleting old packages..."
+
+  # Since we cant remove pkgs via repository, this will have to do
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} query -e '%n !~ FreeBSD-*' %o | \
+	xargs ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} delete -fy >>${LOGOUT} 2>>${LOGOUT}
+  if [ $? -ne 0 ] ; then
+    echo_log "FAILED: Deleting old packages..."
+    exit 1
+  fi
+
   # Remove *ALL* the packages, we need a clean slate to avoid pkg conflicts going sideways
   ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} delete -yg \* >>${LOGOUT} 2>>${LOGOUT}
   if [ $? -ne 0 ] ; then
-    echo_log "FAILED Cleaning packages"
+    echo_log "FAILED Deleting old base packages"
     exit 1
   fi
 
@@ -584,17 +601,23 @@ prep_pkgs_chroot()
     BLACKLISTPKG="$(jq -r '."blacklist" | join (" ")' /etc/trueos-base.json)"
   fi
 
-  # Install the base system packages first
-  echo_log "Installing base packages..."
-  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} search -g 'FreeBSD-*' \
-	| awk '{print $1}'  > /tmp/.fpkg.$$
+  # Set the default ABI
+  FBVER=$(${PKG_CMD} ${PKG_CFLAG} ${PKG_FLAG} rquery '%v' FreeBSD-runtime | cut -d '.' -f 1)
+  ABI="FreeBSD:${FBVER}:`uname -m`"
+  ABI_FLAG="-o ABI=$ABI"
+  export ABI_FLAG
+  echo_log "Setting new system ABI to: $ABI"
+
+  # Install new base packages
   while read fpkg
   do
+    SKIP=0
     echo "$fpkg" | grep -q -e '-development-'
     if [ $? -eq 0 -a "$DEVPKG" = "YES" ] ; then
       echo_log "Skipping DEVELOPMENT package: $fpkg"
       continue
     fi
+    echo "$fpkg" | grep -q -e '-debug-'
     if [ $? -eq 0 -a "$DEBUGPKG" = "YES" ] ; then
       echo_log "Skipping DEBUG package: $fpkg"
       continue
@@ -604,10 +627,14 @@ prep_pkgs_chroot()
     do
        echo $fpkg | grep -q -e "FreeBSD-$i-"
        if [ $? -eq 0 ] ; then
-         echo_log "Skipping BLACKLIST package: $fpkg"
-         continue
+	 SKIP=1
+	 break
        fi
     done
+    if [ $SKIP -eq 1 ] ; then
+         echo_log "Skipping BLACKLIST package: $fpkg"
+	 continue
+    fi
 
     ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} info -q $fpkg
     if [ $? -eq 0 ] ; then
@@ -615,10 +642,12 @@ prep_pkgs_chroot()
       continue
     fi
 
+
     # Install the base system package now
-    ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} install -yf $fpkg >>${LOGOUT} 2>>${LOGOUT}
+    echo_log "Installing: $fpkg"
+    ${PKG_CMD} -r ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} install -U -yf $fpkg >>${LOGOUT} 2>>${LOGOUT}
     if [ $? -ne 0 ] ; then
-      echo_log "FAILED INSTALLING world base package: $fpkg"
+      echo_log "FAILED: Installing world base package: $fpkg"
       rm /tmp/.fpkg.$$
       exit 1
     fi

--- a/trueos-update
+++ b/trueos-update
@@ -560,9 +560,17 @@ prep_pkgs_chroot()
   # Unlock all packages first
   ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} unlock -ay >>${LOGOUT} 2>>${LOGOUT}
 
-  # Upgrade the base system packages first
+
+  # Remove *ALL* the packages, we need a clean slate to avoid pkg conflicts going sideways
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} delete -yg \* >>${LOGOUT} 2>>${LOGOUT}
+  if [ $? -ne 0 ] ; then
+    echo_log "FAILED Cleaning packages"
+    exit 1
+  fi
+
+  # Install the base system packages first
   echo_log "Upgrading base packages..."
-  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} upgrade -yfg 'FreeBSD-*' >>${LOGOUT} 2>>${LOGOUT}
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} install -yfg 'FreeBSD-*' >>${LOGOUT} 2>>${LOGOUT}
   if [ $? -ne 0 ] ; then
     echo_log "FAILED INSTALLING world base packages"
     exit 1
@@ -570,21 +578,17 @@ prep_pkgs_chroot()
 
   # Set all pkgs as not auto-installed, so pkg autoremove doesn't touch them
   echo_log "Marking FreeBSD packages as not auto-installed"
-  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} set -y -A 00 -g FreeBSD-\* >>${LOGOUT} 2>>${LOGOUT}
+  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} set -y -A 00 -g FreeBSD-\* >>${LOGOUT} 2>>${LOGOUT}
 
   # Check if something went horribly wrong
   if [ ! -e "${STAGEMNT}/bin/sh" ] ; then
      ABI_FLAG="-o ABI=freebsd:`uname -r | cut -c 1-2`:`uname -m`"
-     ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} upgrade -yfg 'FreeBSD-*' >>${LOGOUT} 2>>${LOGOUT}
+     ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} install -yfg 'FreeBSD-*' >>${LOGOUT} 2>>${LOGOUT}
      if [ ! -e "${STAGEMNT}/bin/sh" ] ; then
        echo_log "Missing ${STAGEMNT}/bin/sh: Something went horribly wrong!"
        exit 1
      fi
   fi
-
-  # Work around an issue with some kmod pkgs which can hang the box before upgrade happens
-  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} delete -yg '*kmod*' >>${LOGOUT} 2>>${LOGOUT}
-  ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} delete -yg '*nvidia-driver*' >>${LOGOUT} 2>>${LOGOUT}
 
   # Workaround to issue in FreeBSD pkg base
   chown root:operator ${STAGEMNT}/sbin/shutdown

--- a/trueos-update
+++ b/trueos-update
@@ -579,6 +579,11 @@ prep_pkgs_chroot()
     exit 1
   fi
 
+  # Set any blacklist items
+  if [ -e "/etc/trueos-base.json" ] ; then
+    BLACKLISTPKG="$(jq -r '."blacklist" | join (" ")' /etc/trueos-base.json)"
+  fi
+
   # Install the base system packages first
   echo_log "Installing base packages..."
   ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} search -g 'FreeBSD-*' \
@@ -594,6 +599,15 @@ prep_pkgs_chroot()
       echo_log "Skipping DEBUG package: $fpkg"
       continue
     fi
+
+    for i in $BLACKLISTPKG
+    do
+       echo $fpkg | grep -q -e "FreeBSD-$i-"
+       if [ $? -eq 0 ] ; then
+         echo_log "Skipping BLACKLIST package: $fpkg"
+         continue
+       fi
+    done
 
     ${PKG_CMD} -c ${STAGEMNT} ${PKG_CFLAG} ${PKG_FLAG} ${ABI_FLAG} info -q $fpkg
     if [ $? -eq 0 ] ; then


### PR DESCRIPTION
This converts us to doing a fresh-install of all packages into a new BE at update time. To prevent issues with files already on disk from old packages conflicting with incoming pkg updates in FreeBSD base.